### PR TITLE
Delay checking for TREUNAS_INSTALL label while installing

### DIFF
--- a/truenas/zfs-initrd
+++ b/truenas/zfs-initrd
@@ -74,6 +74,22 @@ mkdir -p "${1}/sbin"
 cat >"${1}/sbin/start-truenas-install" << EOF
 #!/bin/sh
 
+for i in 1 2 3 4 5;
+do
+	if [ -e /dev/disk/by-label/TRUENAS_INSTALL ]; then
+		break
+	else
+		echo "Waiting 5 seconds for root device to settle"
+		sleep 5
+	fi
+done
+
+if [ ! -e /dev/disk/by-label/TRUENAS_INSTALL ]; then
+	echo "Unable to find /dev/disk/by-label/TRUENAS_INSTALL, dropping to shell"
+	/bin/sh
+	exit 1
+fi
+
 # Mount CDROM
 mkdir /cdrom
 mount -t iso9660 /dev/disk/by-label/TRUENAS_INSTALL /cdrom


### PR DESCRIPTION
This commit introduces changes where we delay checking for TRUENAS_INSTALL label while installing because USB drives can take some time to show up properly in the OS. If this still fails for some reason, we drop to shell then.